### PR TITLE
Added info on Twitter credentials file format

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,17 @@ You'll need to install the requirements
 pip install -r requirements.txt
 ```
 
-## Install twitter credentials:
-Next, you will also need to sign up for twitter, obtain API credentials, and add those credentials to `twitter_secrets.json.nogit` (this file is intentionally ignored by git).  You can obtain your API credentials on the [Twitter API page](http://apps.twitter.com/)
+## Add Twitter credentials:
+Next, you will also need to sign up for Twitter, obtain API credentials, and add those credentials to `twitter_secrets.json.nogit` (this file is intentionally ignored by git).  You can obtain your API credentials on the [Twitter API page](http://apps.twitter.com/). This file must be in JSON format so that the SimpleJSON package can read it, which will look something like: 
+```
+{
+"api_key": "XXXX",
+"api_secret": "XXXX",
+"access_token": "XXXX",
+"access_token_secret": "XXXX"
+}
+```
+where the XXXX values are yours.
 
 ## Run:
 To run this demo, you will need to startup an ipython notebook instance:


### PR DESCRIPTION
Updates the README to describe the correct format for the Twitter credentials file, `twitter_secrets.json.git`.
